### PR TITLE
ELP Application For H264

### DIFF
--- a/sources/meta-ornl/recipes-multimedia/elp-h264/elp-h264.bb
+++ b/sources/meta-ornl/recipes-multimedia/elp-h264/elp-h264.bb
@@ -1,0 +1,26 @@
+SUMMARY = "ELP UVC H.264 Linux Binary"
+LICENSE = "CLOSED"
+
+FILESEXTRAPATH_prepend := "${THISDIR}/${PN}:"
+
+SRCBRANCH ?= "master"
+SRCREV = "274fb791469b453d7945aa854e94bdd0798cb723"
+SRC_URI = "git://github.com/yokeap/ELP_H264_UVC.git;protocol=https;branch=${SRCBRANCH} \
+    file://UvcChanges.patch \
+"
+
+S = "${WORKDIR}/git/Linux_UVC_TestAP/"
+INSANE_SKIP_${PN} = "ldflags"
+
+FILES_${PN} += "/usr/bin/H264_UVC_TestAP"
+
+do_compile() {
+    make all
+}
+
+do_install() {
+    mkdir -p ${D}/usr/bin/
+    install -d ${D}/usr/bin/
+
+    install -m 0755 ${S}H264_UVC_TestAP ${D}/usr/bin/
+}

--- a/sources/meta-ornl/recipes-multimedia/elp-h264/files/UvcChanges.patch
+++ b/sources/meta-ornl/recipes-multimedia/elp-h264/files/UvcChanges.patch
@@ -1,0 +1,34 @@
+diff --git a/H264_UVC_TestAP.c b/H264_UVC_TestAP.c
+index 7a86fbe..a5ddb6c 100644
+--- a/H264_UVC_TestAP.c
++++ b/H264_UVC_TestAP.c
+@@ -143,8 +143,8 @@ static int CheckKernelVersion(void)
+ 	else
+ 	{
+ 		TestAp_Printf(TESTAP_DBG_ERR, "your kernel version: 0x%x \nTestAP support kernel version: 0x%x\n",kernelRelease, LINUX_VERSION_CODE);
+-		return false;
+ 	}
++	return true;
+ 
+ }
+ static int GetFreeRam(int* freeram)
+@@ -1858,6 +1858,7 @@ int main(int argc, char *argv[])
+ 			break;
+ 
+ 		case OPT_H264_IFRAME_SET:
++			TestAp_Printf(TESTAP_DBG_ERR, "IFrame chosen\n");
+ 			h264_iframe_reset = atoi(optarg);
+ 			do_h264_iframe_set = 1;
+ 			break;
+@@ -2121,6 +2122,11 @@ int main(int argc, char *argv[])
+ 			TestAp_Printf(TESTAP_DBG_ERR, "RERVISION_UVC_TestAP @main : XU_H264_Set_BitRate Failed\n");
+ 	}
+ 
++	if(do_h264_iframe_set)
++	{
++		XU_H264_Set_IFRAME(dev);
++	}
++
+ 	if(do_xu_set)
+ 	{
+ 		TestAp_Printf(TESTAP_DBG_FLOW, "== XU Set: input command ==\n");		


### PR DESCRIPTION
This compiles an application to use in conjunction with the ELP cameras.  It allows for more control over pulling h264 directly from the camera.