### PR TITLE
Dunfell Serial Patch

### DIFF
--- a/sources/meta-ornl/recipes-core/images/ornl-dev-image.bb
+++ b/sources/meta-ornl/recipes-core/images/ornl-dev-image.bb
@@ -59,6 +59,7 @@ IMAGE_INSTALL_append += " \
 	python3-lxml \
 	python3-mavproxy \
 	python3-netifaces \
+	python3-numpy \
 	python3-pexpect \
 	python3-pip \
 	python3-protobuf \

--- a/sources/meta-ornl/recipes-kernel/linux/linux-variscite/var-som-mx6-ornl/uvdl_kernel_mxc3.patch
+++ b/sources/meta-ornl/recipes-kernel/linux/linux-variscite/var-som-mx6-ornl/uvdl_kernel_mxc3.patch
@@ -1,0 +1,36 @@
+diff --git a/arch/arm/boot/dts/imx6q-iris2-R0.dts b/arch/arm/boot/dts/imx6q-iris2-R0.dts
+index 821b6d668a12..06f7536b4b88 100644
+--- a/arch/arm/boot/dts/imx6q-iris2-R0.dts
++++ b/arch/arm/boot/dts/imx6q-iris2-R0.dts
+@@ -177,6 +177,7 @@
+ &uart4 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pinctrl_uart4_1>;
++	dma-names = "", "";
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/boot/dts/imx6q-iris2-R1.dts b/arch/arm/boot/dts/imx6q-iris2-R1.dts
+index 578b3196b9ef..aff7181c3e89 100644
+--- a/arch/arm/boot/dts/imx6q-iris2-R1.dts
++++ b/arch/arm/boot/dts/imx6q-iris2-R1.dts
+@@ -252,6 +252,7 @@
+ &uart4 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pinctrl_uart4_1>;
++	dma-names = "", "";
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/boot/dts/imx6q-nightcrawler-R0.dts b/arch/arm/boot/dts/imx6q-nightcrawler-R0.dts
+index 40cae1f40259..30bdccf1ba35 100644
+--- a/arch/arm/boot/dts/imx6q-nightcrawler-R0.dts
++++ b/arch/arm/boot/dts/imx6q-nightcrawler-R0.dts
+@@ -244,6 +244,7 @@
+ &uart4 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pinctrl_uart4_1>;
++	dma-names = "", "";
+ 	status = "okay";
+ };
+ 

--- a/sources/meta-ornl/recipes-kernel/linux/linux-variscite_5.4.bbappend
+++ b/sources/meta-ornl/recipes-kernel/linux/linux-variscite_5.4.bbappend
@@ -6,6 +6,7 @@ LOCALVERSION_var-som-mx6-ornl = "-imx6ul"
 SRC_URI_append += " file://uvdl_kernel_5-4.patch \
     file://imx_v7_iris2_defconfig \
     file://uvdl_kernel_otp.patch \
+    file://uvdl_kernel_mxc3.patch \
 "
 
 KBUILD_DEFCONFIG_var-som-mx6-ornl = "imx_v7_iris2_defconfig"


### PR DESCRIPTION
This PR incorporates the null'd out dna-names to the the serial port ttymxc3.  It was missed on the last patch, due to the fact we were only checking sat and not the autopilot port.  It also adds numpy to the base dev image.