### PR TITLE
RPI4 32 Bit Image Addition

### DIFF
--- a/BuildScripts/ornl-bitbake.sh
+++ b/BuildScripts/ornl-bitbake.sh
@@ -63,6 +63,8 @@ jetson-xavier-nx-devkit)
 	cd ${YOCTO_DIR}
 	source ${YOCTO_DIR}/ornl-yocto-tegra/setup-env --machine ${MACHINE} --distro ornl-tegra ${YOCTO_ENV}
 	;;
+raspberrypi4)
+	;&
 raspberrypi4-64)
 	cd ${YOCTO_DIR}
 	source ${YOCTO_DIR}/ornl-yocto-rpi/layers/poky/oe-init-build-env ${YOCTO_ENV}

--- a/BuildScripts/ornl-create-archive.sh
+++ b/BuildScripts/ornl-create-archive.sh
@@ -163,7 +163,7 @@ if [[ ($MACHINE == var-som-mx6 || $MACHINE == var-som-mx6-ornl) ]] ; then
 elif [[ $MACHINE == *jetson* ]] ; then
 	cp -f ${YOCTO_DIR}/${YOCTO_ENV}/tmp/deploy/images/${MACHINE}/tegra-${YOCTO_PROD}-full-image-${MACHINE}.tegraflash.tar.gz ${_OUT}
 
-elif [[ $MACHINE == raspberrypi4-64 ]] ; then
+elif [[ $MACHINE == *raspberrypi* ]] ; then
 	cp -f ${YOCTO_DIR}/${YOCTO_ENV}/tmp-glibc/deploy/images/${MACHINE}/raspberrypi-${YOCTO_PROD}-full-image-${MACHINE}.wic.bz2 ${_OUT}
 	( cd ${_OUT} && bzip2 -d raspberrypi-${YOCTO_PROD}-full-image-${MACHINE}.wic.bz2 )
 

--- a/BuildScripts/ornl-setup-yocto.sh
+++ b/BuildScripts/ornl-setup-yocto.sh
@@ -133,6 +133,8 @@ function run_build()
     jetson-xavier-nx-devkit)
         sync_tegra_platform
         ;;
+    raspberrypi4)
+        ;&
     raspberrypi4-64)
         sync_raspberries
         ;;
@@ -635,6 +637,8 @@ function make_build_dir()
         fi
         eval cd ${OLD_DIR}
         ;;
+    raspberrypi4)
+        ;&
     raspberrypi4-64)
         eval cd $YOCTO_DIR_LOCATION/
         # Run standard OE setup script
@@ -699,6 +703,8 @@ function copy_config_files()
     var-som-mx6-ornl)
         MACHINE_FOLDER="variscite"
         ;;
+    raspberrypi4)
+        ;&
     raspberrypi4-64)
         MACHINE_FOLDER="raspberrypi"
         ;;

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ YOCTO_DISTRO=fslc-framebuffer
 YOCTO_IMG=var-$(YOCTO_PROD)-update-full-image
 YOCTO_DIR := $(EPHEMERAL)/$(PROJECT)-$(YOCTO_VERSION)
 ARCHIVE_DIR=$(ARCHIVE)/var-$(DATE)
-else ifeq ($(strip $(MACHINE)),raspberrypi4-64)
+else ifneq (,$(findstring raspberrypi, $(MACHINE)))
 MACHINE_FOLDER=raspberrypi
 YOCTO_VERSION=dunfell
 YOCTO_DISTRO=ornl-rpi
@@ -345,7 +345,7 @@ ifeq ($(strip $(MACHINE)),var-som-mx6-ornl)
 		MACHINE=$(MACHINE) DISTRO=$(YOCTO_DISTRO) EULA=$(EULA) . setup-environment $(YOCTO_ENV) && \
 		cd $(YOCTO_DIR)/$(YOCTO_ENV) && \
 		bitbake -c cleanall $(RECIPE)
-else ifeq ($(strip $(MACHINE)),raspberrypi4-64)
+else ifneq (,$(findstring raspberrypi, $(MACHINE)))
 	@cd $(YOCTO_DIR) && \
 		source ${YOCTO_DIR}/ornl-yocto-rpi/layers/poky/oe-init-build-env ${YOCTO_ENV} && \
 		cd $(YOCTO_DIR)/$(YOCTO_ENV) && \

--- a/build/conf/raspberrypi/local.conf
+++ b/build/conf/raspberrypi/local.conf
@@ -1,3 +1,5 @@
+#MACHINE ?= "raspberrypi4"
+# Default machine will be the arm64 version
 MACHINE ??= 'raspberrypi4-64'
 DISTRO ?= 'ornl-rpi'
 

--- a/sources/meta-ornl/conf/distro/ornl-rpi.conf
+++ b/sources/meta-ornl/conf/distro/ornl-rpi.conf
@@ -6,6 +6,8 @@ DISTRO_FEATURES_remove = " nfs"
 VIRTUAL-RUNTIME_initscripts = ""
 VOLATILE_LOG_DIR = "no"
 
+MACHINE_FEATURES_append_raspberrypi4 += " libegl-mesa"
+
 # Need nmcli for our distrobution
 NETWORK_MANAGER ?= "networkmanager"
 

--- a/sources/meta-ornl/recipes-core/images/ornl-dev-image.bb
+++ b/sources/meta-ornl/recipes-core/images/ornl-dev-image.bb
@@ -33,6 +33,7 @@ IMAGE_INSTALL_append += " \
 	gpsd \
 	gps-utils \
 	gstd \
+	gstreamer1.0-plugins-base \
 	gstreamer1.0-plugins-good \
 	gstreamer1.0-plugins-bad \
 	gstreamer1.0-plugins-ugly \

--- a/sources/meta-ornl/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/sources/meta-ornl/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -3,7 +3,15 @@ EXTRA_OECONF += "--enable-x265"
 
 DEPENDS += " x265"
 
+# Even though they contain the same, I thought it best
+# to keep machine specifics separate in case of future add-ons
+
 PACKAGECONFIG_var-som-mx6-ornl += " \ 
+    rtmp \
+    voaacenc \
+"
+
+PACKAGECONFIG_raspberrypi4-64 += " \
     rtmp \
     voaacenc \
 "

--- a/sources/meta-ornl/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
+++ b/sources/meta-ornl/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_%.bbappend
@@ -1,0 +1,4 @@
+PACKAGECONFIG_raspberrypi4-64 += " \
+    alsa \ 
+    jpeg \
+"

--- a/sources/meta-ornl/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
+++ b/sources/meta-ornl/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
@@ -3,3 +3,8 @@ PACKAGECONFIG_var-som-mx6-ornl += " \
     speex \
     soup \
 "
+
+PACKAGECONFIG_raspberrypi4-64 += " \
+    jpeg \ 
+    v4l2 \  
+"

--- a/sources/meta-ornl/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_%.bbappend
+++ b/sources/meta-ornl/recipes-multimedia/gstreamer/gstreamer1.0-plugins-ugly_%.bbappend
@@ -1,9 +1,9 @@
-EXTRA_OECONF_remove = "--disable-x264"
-EXTRA_OECONF += "--enable-x264"
+EXTRA_OECONF_remove_var-som-mx6-ornl = "--disable-x264"
+EXTRA_OECONF_var-som-mx6-ornl += "--enable-x264"
 
-DEPENDS += " x264"
+DEPENDS_var-som-mx6-ornl += " x264"
 
-PACKAGECONFIG += " \
+PACKAGECONFIG_var-som-mx6-ornl += " \
     x264 \
 "
 

--- a/sources/meta-ornl/recipes-raspberrypi/images/raspberrypi-dev-full-image.bb
+++ b/sources/meta-ornl/recipes-raspberrypi/images/raspberrypi-dev-full-image.bb
@@ -9,11 +9,18 @@ require recipes-core/images/ornl-dev-image.bb
 # NOTE if using Gatesgarth use Networkmanager-nmcli it is separated out into
 # different packages for that version
 
+IMAGE_INSTALL_append_raspberrypi4-64 += " \
+	gstreamer1.0-libav \
+"	
+
+IMAGE_INSTALL_append_raspberrypi4 += " \
+	gstreamer-omx \
+	userland \
+"
+
 IMAGE_INSTALL_append = " \
 	gstreamer1.0 \
-	gstreamer1.0-omx \
 	gstreamer1.0-rtsp-server \
-	gstreamer1.0-vaapi \
 	packagegroup-core-full-cmdline \
 	mender-client \
 	perf \

--- a/sources/meta-ornl/recipes-raspberrypi/images/raspberrypi-dev-full-image.bb
+++ b/sources/meta-ornl/recipes-raspberrypi/images/raspberrypi-dev-full-image.bb
@@ -15,7 +15,6 @@ IMAGE_INSTALL_append_raspberrypi4-64 += " \
 
 IMAGE_INSTALL_append_raspberrypi4 += " \
 	gstreamer1.0-omx \
-	userland \
 "
 
 IMAGE_INSTALL_append = " \

--- a/sources/meta-ornl/recipes-raspberrypi/images/raspberrypi-dev-full-image.bb
+++ b/sources/meta-ornl/recipes-raspberrypi/images/raspberrypi-dev-full-image.bb
@@ -11,6 +11,9 @@ require recipes-core/images/ornl-dev-image.bb
 
 IMAGE_INSTALL_append = " \
 	gstreamer1.0 \
+	gstreamer1.0-omx \
+	gstreamer1.0-rtsp-server \
+	gstreamer1.0-vaapi \
 	packagegroup-core-full-cmdline \
 	mender-client \
 	perf \

--- a/sources/meta-ornl/recipes-raspberrypi/images/raspberrypi-dev-full-image.bb
+++ b/sources/meta-ornl/recipes-raspberrypi/images/raspberrypi-dev-full-image.bb
@@ -14,7 +14,7 @@ IMAGE_INSTALL_append_raspberrypi4-64 += " \
 "	
 
 IMAGE_INSTALL_append_raspberrypi4 += " \
-	gstreamer-omx \
+	gstreamer1.0-omx \
 	userland \
 "
 


### PR DESCRIPTION
We needed to add a 32 bit version of the RPI build so we can incorporate the OpenMax libs for some video work we have done in the past.